### PR TITLE
Fix Linux build: Use PNG icon instead of ICO for AppImage

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,8 @@
         }
       ],
       "category": "Audio",
-      "maintainer": "Music Scan Pro <contact@musicscanpro.com>"
+      "maintainer": "Music Scan Pro <contact@musicscanpro.com>",
+      "icon": "icon.png"
     },
     "dmg": {
       "title": "Music Scan Pro",


### PR DESCRIPTION
- Add icon.png specification to Linux build configuration
- Linux AppImage requires PNG format and minimum 256x256 pixels
- Current icon.png is 722x722 which meets requirements
- Windows builds continue using ICO format as appropriate

This should resolve the Linux build error: 'image must be at least 256x256'