### PR TITLE
fix: Prevent releases from non-main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,22 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch full history to check tag ancestry
+        
+    - name: Check if tag is on main branch
+      run: |
+        # Fetch main branch to check tag ancestry
+        git fetch origin main
+        
+        # Check if the current tag commit is reachable from main
+        if ! git merge-base --is-ancestor HEAD origin/main; then
+          echo "❌ Tag is not on main branch. Releases can only be created from main branch."
+          echo "Please merge your changes to main first, then create the tag from main."
+          exit 1
+        fi
+        
+        echo "✅ Tag is on main branch. Proceeding with release..."
 
     - name: Download Windows artifacts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
- Add branch ancestry check to release workflow
- Releases can now only be created from tags on main branch
- Fixes issue where dev branch tags triggered releases
- Ensures proper release workflow with stable code from main